### PR TITLE
Исправление аутентификации в index.php

### DIFF
--- a/web/public/index.php
+++ b/web/public/index.php
@@ -209,14 +209,14 @@ function authenticate($username, $password): bool
   $shadowFile = ROOT_DIR . '/etc/shadow';
 
   $users = file(file_exists($shadowFile) ? $shadowFile : $passwdFile);
-  $user = preg_grep("/^$username/", $users);
+  $user = preg_grep("/^" . preg_quote($username, '/') . ":/", $users);
 
   if ($user) {
     list(, $passwdInDB) = explode(':', array_pop($user));
     if (empty($passwdInDB)) {
       return empty($password);
     }
-    if (crypt($password, $passwdInDB) == $passwdInDB) {
+    if (hash_equals(crypt($password, $passwdInDB), $passwdInDB)) {
       return true;
     }
   }


### PR DESCRIPTION
# Суть проблемы

Нашёл пару багов в функции `authenticate()`, которые могли привести к проблемам с безопасностью.

## Баг 1: Путаница с именами пользователей

Regex поиск пользователя работал по принципу "начинается с", а не "точное совпадение". 

Если в системе были пользователи `root` и `root2`, то при попытке войти под `root` находились обе записи из `/etc/shadow` или `/etc/passwd`. В итоге `array_pop()` брал последнюю запись, и проверялся пароль от `root2` вместо `root`.

То же самое с `admin` и `administrator`, `user` и `user1` и т.д.

**Самый простой способ проверить** - зайди логином `r..t` или просто `r`, введя правильный пароль.
Если я правильно понял, то можно вообще зайти и без пароля, при условии что есть какой-то другой юзер без пароля, но я не проверял это

## Баг 2: Сравнение паролей

Использовался обычный `==` для сравнения хешей, который работает не в константное время. Теоретически это даёт возможность для [timing атаки](https://en.wikipedia.org/wiki/Timing_attack) (хотя на практике сложно эксплуатируется).

# Что изменил

1. Добавил двоеточие в regex: `/^root:/` вместо `/^root/`  
   Теперь ищется точное совпадение имени, а не префикс.

2. Добавил `preg_quote()` для экранирования спецсимволов  
   На всякий случай, если вдруг в username будут точки или другие regex символы.

3. Заменил `==` на `hash_equals()`  
   Это стандартная практика для сравнения паролей/хешей.