### PR TITLE
Fix log domain highlighting for domains starting with digits

### DIFF
--- a/web/src/utils/codeMirrorLangLog.ts
+++ b/web/src/utils/codeMirrorLangLog.ts
@@ -181,7 +181,7 @@ function logTokenBase(stream: StringStream, _state: LogState): string | null {
   }
 
   // Other long hex-ish ids (at least 12 chars, with letters+digits) as a single token
-  if (stream.match(/^[0-9a-f]{12,}/i, true)) {
+  if (stream.match(/^[0-9a-f]{12,}(?![A-Za-z0-9_.-])/i, true)) {
     return 'string-2';
   }
 
@@ -189,7 +189,7 @@ function logTokenBase(stream: StringStream, _state: LogState): string | null {
   if (stream.match(/^\d+\/\d+/, true)) {
     return 'number';
   }
-  if (stream.match(/^\d+/, true)) {
+  if (stream.match(/^\d+(?![A-Za-z0-9_.-])/, true)) {
     return 'number';
   }
 


### PR DESCRIPTION
Маленький фикс подсветки синтаксиса, если домен например или зеркало домена начиналось с цифр, то они бы подсвечивались в самом начале. Пример ниже. На усмотрение
Было:
<img width="951" height="163" alt="Снимок экрана 2026-02-09 194459" src="https://github.com/user-attachments/assets/7f192837-4d14-432a-888b-5ca2fc4b7bb0" />
Стало:
<img width="932" height="151" alt="Снимок экрана 2026-02-09 194528" src="https://github.com/user-attachments/assets/e88f8f5e-eac4-467a-aee6-272892813eaa" />
