### PR TITLE
Add minimal syntax highlighting for .list files (comments only)

### DIFF
--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -20,6 +20,7 @@ import {
   codeMirrorLangNfqws,
   codeMirrorLangNfqwsArgs,
 } from '@/utils/codeMirrorLangNfqws';
+import { codeMirrorLangList } from '@/utils/codeMirrorLangList';
 
 const historyCompartment = new Compartment();
 
@@ -72,6 +73,8 @@ export const Editor = ({
       result.push(codeMirrorLangNfqws());
     } else if (type === 'arg') {
       result.push(codeMirrorLangNfqwsArgs());
+    } else if (type === 'list') {
+      result.push(codeMirrorLangList());
     } else if (type === 'log') {
       result.push(codeMirrorLangLog());
     } else if (type === 'lua') {

--- a/web/src/utils/codeMirrorLangList.ts
+++ b/web/src/utils/codeMirrorLangList.ts
@@ -1,0 +1,47 @@
+// CodeMirror 6 language support for nfqws *.list (comments only)
+
+import {
+  LanguageSupport,
+  StreamLanguage,
+  type StringStream,
+} from '@codemirror/language';
+
+type ListState = {
+  tokenize: (stream: StringStream, state: ListState) => string | null;
+};
+
+function tokenBase(stream: StringStream, _state: ListState): string | null {
+  // Line comments only (starting with #, after optional spaces)
+  if (stream.sol()) {
+    stream.eatSpace();
+
+    if (stream.peek() === '#') {
+      stream.skipToEnd();
+      return 'comment';
+    }
+  }
+
+  stream.skipToEnd();
+  return null;
+}
+
+export const nfqwsListStream = StreamLanguage.define<ListState>({
+  name: 'nfqws-list',
+  startState() {
+    const state: ListState = {
+      tokenize: tokenBase,
+    };
+    return state;
+  },
+  token(stream, state) {
+    if (stream.eatSpace()) return null;
+    return state.tokenize(stream, state);
+  },
+  languageData: {
+    commentTokens: { line: '#' },
+  },
+});
+
+export function codeMirrorLangList() {
+  return new LanguageSupport(nfqwsListStream);
+}


### PR DESCRIPTION
Было бы удобно добавить подсветку комментариев в листы, в больших списках удобная навигация при скролле, чтоб не сливалось ни чего, конечно есть ctrl+f, но все же, структуру вроде бы сохранил 🙌
Было:
<img width="299" height="350" alt="изображение" src="https://github.com/user-attachments/assets/97f656d8-9855-43c8-9759-6c52015d0148" />

Стало:
<img width="288" height="351" alt="Снимок экрана 2026-02-13 003805" src="https://github.com/user-attachments/assets/8674278f-526f-4d27-8fec-203a491a1490" />
